### PR TITLE
PriRequestURLEncodedValues Haxe 4.0+ compilation support

### DIFF
--- a/priori/net/PriRequestURLEncodedValues.hx
+++ b/priori/net/PriRequestURLEncodedValues.hx
@@ -2,7 +2,11 @@ package priori.net;
 
 import js.jquery.JQuery;
 
+#if (haxe_ver >= 4.0)
+class PriRequestURLEncodedValues {
+#else
 class PriRequestURLEncodedValues implements Dynamic {
+#end
 
     public function new() {
 


### PR DESCRIPTION
Under Haxe 4.0+, the "implements Dynamic" throws compilation error. Apparently this is the fix.